### PR TITLE
Add tipg, CDNs and STAC browser, make bastion host optional, update README, bump eoapi-cdk, clean up the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # eoapi-template
+
 Demonstration application showing the use and configuration options of the [eoapi-cdk constructs](https://github.com/developmentseed/eoapi-cdk) on AWS.
+
+## Requirements
+
+- python
+- docker
+- the AWS CDK CLI
+- AWS credentials environment variables configured to point to an account. 
+- **Optional** a `config.yaml` file to override the default deployment settings defined in `config.py`.
+
+## Installation
+
+```
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -r requirements.txt
+```
+
+## Deployment
+
+First, synthesize the app 
+
+```
+cdk synth --all
+```
+
+Then, deploy
+
+```
+cdk deploy --all --require-approval never
+```

--- a/app.py
+++ b/app.py
@@ -1,47 +1,17 @@
-import yaml
 from aws_cdk import App
 
-from config import Config
+from config import build_app_config
 from eoapi_template import pgStacInfra, vpc
 
 app = App()
 
-try:
-    with open("config.yaml") as f:
-        config = yaml.safe_load(f)
-        config = (
-            {} if config is None else config
-        )  # if config is empty, set it to an empty dict
-        config = Config(**config)
-except FileNotFoundError:
-    # if no config at the expected path, using defaults
-    config = Config()
+app_config = build_app_config()
 
-vpc_stack = vpc.VpcStack(
-    tags=config.tags,
-    scope=app,
-    id=config.build_service_name("pgSTAC-vpc"),
-    nat_gateway_count=config.nat_gateway_count,
-)
-
+vpc_stack = vpc.VpcStack(scope=app, app_config=app_config)
 
 pgstac_infra_stack = pgStacInfra.pgStacInfraStack(
     scope=app,
-    tags=config.tags,
-    id=config.build_service_name("pgSTAC-infra"),
     vpc=vpc_stack.vpc,
-    stac_api_lambda_name=config.build_service_name("STAC API"),
-    titiler_pgstac_api_lambda_name=config.build_service_name("titiler pgSTAC API"),
-    tipg_api_lambda_name=config.build_service_name("tipg API"),
-    stage=config.stage,
-    db_allocated_storage=config.db_allocated_storage,
-    public_db_subnet=config.public_db_subnet,
-    db_instance_type=config.db_instance_type,
-    bastion_host_allow_ip_list=config.bastion_host_allow_ip_list,
-    bastion_host_create_elastic_ip=config.bastion_host_create_elastic_ip,
-    bastion_host_user_data=yaml.dump(config.bastion_host_user_data),
-    titiler_buckets=config.titiler_buckets,
-    data_access_role_arn=config.data_access_role_arn,
-    auth_provider_jwks_url=config.auth_provider_jwks_url,
+    app_config=app_config,
 )
 app.synth()

--- a/app.py
+++ b/app.py
@@ -32,6 +32,7 @@ pgstac_infra_stack = pgStacInfra.pgStacInfraStack(
     vpc=vpc_stack.vpc,
     stac_api_lambda_name=config.build_service_name("STAC API"),
     titiler_pgstac_api_lambda_name=config.build_service_name("titiler pgSTAC API"),
+    tipg_api_lambda_name=config.build_service_name("tipg API"),
     stage=config.stage,
     db_allocated_storage=config.db_allocated_storage,
     public_db_subnet=config.public_db_subnet,

--- a/config.py
+++ b/config.py
@@ -81,6 +81,32 @@ class AppConfig(BaseSettings):
         buckets to grant access to the titiler API""",
         default=[],
     )
+    acm_certificate_arn: Optional[str] = pydantic.Field(
+        description="""ARN of ACM certificate to use for 
+        custom domain names. If provided,
+        CDNs are created for all the APIs""",
+        default=None,
+    )
+    stac_api_custom_domain: Optional[str] = pydantic.Field(
+        description="""Custom domain name for the STAC API. 
+        Must provide `acm_certificate_arn`""",
+        default=None,
+    )
+    titiler_pgstac_api_custom_domain: Optional[str] = pydantic.Field(
+        description="""Custom domain name for the titiler pgstac API. 
+        Must provide `acm_certificate_arn`""",
+        default=None,
+    )
+    stac_ingestor_api_custom_domain: Optional[str] = pydantic.Field(
+        description="""Custom domain name for the STAC ingestor API.
+        Must provide `acm_certificate_arn`""",
+        default=None,
+    )
+    tipg_api_custom_domain: Optional[str] = pydantic.Field(
+        description="""Custom domain name for the tipg API. 
+        Must provide `acm_certificate_arn`""",
+        default=None,
+    )
 
     @pydantic.field_validator("tags")
     def default_tags(cls, v, info: FieldValidationInfo):
@@ -94,6 +120,23 @@ class AppConfig(BaseSettings):
                              are to be located in the private subnet of the VPC, NAT
                              gateways are needed to allow egress from the services
                              and therefore `nat_gateway_count` has to be > 0."""
+            )
+        else:
+            return v
+
+    @pydantic.field_validator("acm_certificate_arn")
+    def validate_acm_certificate_arn(cls, v, info: FieldValidationInfo):
+        if v is None and any(
+            [
+                info.data["stac_api_custom_domain"],
+                info.data["titiler_pgstac_api_custom_domain"],
+                info.data["stac_ingestor_api_custom_domain"],
+                info.data["tipg_api_custom_domain"],
+            ]
+        ):
+            raise ValueError(
+                """If any custom domain is provided, 
+                an ACM certificate ARN must be provided"""
             )
         else:
             return v

--- a/config.py
+++ b/config.py
@@ -107,6 +107,13 @@ class AppConfig(BaseSettings):
         Must provide `acm_certificate_arn`""",
         default=None,
     )
+    stac_browser_version: Optional[str] = pydantic.Field(
+        description="""Version of the Radiant Earth STAC browser to deploy.
+        If none provided, no STAC browser will be deployed.
+        If provided, `stac_api_custom_domain` must be provided
+        as it will be used as a backend.""",
+        default=None,
+    )
 
     @pydantic.field_validator("tags")
     def default_tags(cls, v, info: FieldValidationInfo):
@@ -120,6 +127,16 @@ class AppConfig(BaseSettings):
                              are to be located in the private subnet of the VPC, NAT
                              gateways are needed to allow egress from the services
                              and therefore `nat_gateway_count` has to be > 0."""
+            )
+        else:
+            return v
+
+    @pydantic.field_validator("stac_browser_version")
+    def validate_stac_browser_version(cls, v, info: FieldValidationInfo):
+        if v is not None and info.data["stac_api_custom_domain"] is None:
+            raise ValueError(
+                """If a STAC browser version is provided, 
+                a custom domain must be provided for the STAC API"""
             )
         else:
             return v

--- a/eoapi_template/pgStacInfra.py
+++ b/eoapi_template/pgStacInfra.py
@@ -1,6 +1,8 @@
 import boto3
 import yaml
-from aws_cdk import Stack, aws_ec2, aws_iam, aws_rds
+from aws_cdk import Stack, aws_certificatemanager, aws_ec2, aws_iam, aws_rds
+from aws_cdk.aws_apigateway import DomainNameOptions
+from aws_cdk.aws_apigatewayv2_alpha import DomainName
 from constructs import Construct
 from eoapi_cdk import (
     BastionHost,
@@ -60,6 +62,18 @@ class pgStacInfraStack(Stack):
                 if app_config.public_db_subnet
                 else aws_ec2.SubnetType.PRIVATE_WITH_EGRESS
             ),
+            stac_api_domain_name=DomainName(
+                self,
+                "stac-api-domain-name",
+                domain_name=app_config.stac_api_custom_domain,
+                certificate=aws_certificatemanager.Certificate.from_certificate_arn(
+                    self,
+                    "stac-api-cdn-certificate",
+                    certificate_arn=app_config.acm_certificate_arn,
+                ),
+            )
+            if app_config.stac_api_custom_domain
+            else None,
         )
 
         TitilerPgstacApiLambda(
@@ -78,6 +92,18 @@ class pgStacInfraStack(Stack):
                 else aws_ec2.SubnetType.PRIVATE_WITH_EGRESS
             ),
             buckets=app_config.titiler_buckets,
+            titiler_pgstac_api_domain_name=DomainName(
+                self,
+                "titiler-pgstac-api-domain-name",
+                domain_name=app_config.titiler_pgstac_api_custom_domain,
+                certificate=aws_certificatemanager.Certificate.from_certificate_arn(
+                    self,
+                    "titiler-pgstac-api-cdn-certificate",
+                    certificate_arn=app_config.acm_certificate_arn,
+                ),
+            )
+            if app_config.titiler_pgstac_api_custom_domain
+            else None,
         )
 
         TiPgApiLambda(
@@ -95,6 +121,18 @@ class pgStacInfraStack(Stack):
                 if app_config.public_db_subnet
                 else aws_ec2.SubnetType.PRIVATE_WITH_EGRESS
             ),
+            tipg_api_domain_name=DomainName(
+                self,
+                "tipg-api-domain-name",
+                domain_name=app_config.tipg_api_custom_domain,
+                certificate=aws_certificatemanager.Certificate.from_certificate_arn(
+                    self,
+                    "tipg-api-cdn-certificate",
+                    certificate_arn=app_config.acm_certificate_arn,
+                ),
+            )
+            if app_config.tipg_api_custom_domain
+            else None,
         )
 
         if app_config.bastion_host:
@@ -142,6 +180,16 @@ class pgStacInfraStack(Stack):
                 subnet_type=aws_ec2.SubnetType.PRIVATE_WITH_EGRESS
             ),
             api_env=stac_ingestor_env,
+            ingestor_domain_name_options=DomainNameOptions(
+                domain_name=app_config.stac_ingestor_api_custom_domain,
+                certificate=aws_certificatemanager.Certificate.from_certificate_arn(
+                    self,
+                    "stac-ingestor-api-cdn-certificate",
+                    certificate_arn=app_config.acm_certificate_arn,
+                ),
+            )
+            if app_config.stac_ingestor_api_custom_domain
+            else None,
         )
 
         # we can only do that if the role is created here.

--- a/eoapi_template/pgStacInfra.py
+++ b/eoapi_template/pgStacInfra.py
@@ -9,6 +9,7 @@ from eoapi_cdk import (
     PgStacDatabase,
     StacIngestor,
     TitilerPgstacApiLambda,
+    TiPgApiLambda
 )
 
 
@@ -24,6 +25,7 @@ class pgStacInfraStack(Stack):
         db_instance_type: str,
         stac_api_lambda_name: str,
         titiler_pgstac_api_lambda_name: str,
+        tipg_api_lambda_name: str,
         bastion_host_allow_ip_list: list,
         bastion_host_create_elastic_ip: bool,
         titiler_buckets: list,
@@ -80,6 +82,23 @@ class pgStacInfraStack(Stack):
                 else aws_ec2.SubnetType.PRIVATE_WITH_EGRESS
             ),
             buckets=titiler_buckets,
+        )
+        
+        TiPgApiLambda(
+            self,
+            "tipg-api",
+            api_env={
+                "NAME": tipg_api_lambda_name,
+                "description": f"{stage} tipg API"
+            },
+            vpc=vpc,
+            db=pgstac_db.db,
+            db_secret=pgstac_db.pgstac_secret,
+            subnet_selection=aws_ec2.SubnetSelection(
+                subnet_type=aws_ec2.SubnetType.PUBLIC
+                if public_db_subnet
+                else aws_ec2.SubnetType.PRIVATE_WITH_EGRESS
+            )
         )
 
         BastionHost(

--- a/eoapi_template/pgStacInfra.py
+++ b/eoapi_template/pgStacInfra.py
@@ -8,6 +8,7 @@ from eoapi_cdk import (
     BastionHost,
     PgStacApiLambda,
     PgStacDatabase,
+    StacBrowser,
     StacIngestor,
     TiPgApiLambda,
     TitilerPgstacApiLambda,
@@ -191,6 +192,15 @@ class pgStacInfraStack(Stack):
             if app_config.stac_ingestor_api_custom_domain
             else None,
         )
+
+        if app_config.stac_browser_version:
+            StacBrowser(
+                self,
+                "stac-browser",
+                github_repo_tag=app_config.stac_browser_version,
+                stac_catalog_url=f"https://{app_config.stac_api_custom_domain}",
+                website_index_document="index.html",
+            )
 
         # we can only do that if the role is created here.
         # If injecting a role, that role's trust relationship

--- a/eoapi_template/pgStacInfra.py
+++ b/eoapi_template/pgStacInfra.py
@@ -8,8 +8,8 @@ from eoapi_cdk import (
     PgStacApiLambda,
     PgStacDatabase,
     StacIngestor,
+    TiPgApiLambda,
     TitilerPgstacApiLambda,
-    TiPgApiLambda
 )
 
 
@@ -83,14 +83,11 @@ class pgStacInfraStack(Stack):
             ),
             buckets=titiler_buckets,
         )
-        
+
         TiPgApiLambda(
             self,
             "tipg-api",
-            api_env={
-                "NAME": tipg_api_lambda_name,
-                "description": f"{stage} tipg API"
-            },
+            api_env={"NAME": tipg_api_lambda_name, "description": f"{stage} tipg API"},
             vpc=vpc,
             db=pgstac_db.db,
             db_secret=pgstac_db.pgstac_secret,
@@ -98,7 +95,7 @@ class pgStacInfraStack(Stack):
                 subnet_type=aws_ec2.SubnetType.PUBLIC
                 if public_db_subnet
                 else aws_ec2.SubnetType.PRIVATE_WITH_EGRESS
-            )
+            ),
         )
 
         BastionHost(

--- a/eoapi_template/vpc.py
+++ b/eoapi_template/vpc.py
@@ -1,12 +1,17 @@
 from aws_cdk import Stack, aws_ec2
 from constructs import Construct
 
+from config import AppConfig
+
 
 class VpcStack(Stack):
-    def __init__(
-        self, scope: Construct, id: str, nat_gateway_count: int, **kwargs
-    ) -> None:
-        super().__init__(scope, id, **kwargs)
+    def __init__(self, scope: Construct, app_config: AppConfig, **kwargs) -> None:
+        super().__init__(
+            scope,
+            id=app_config.build_service_name("pgSTAC-vpc"),
+            tags=app_config.tags,
+            **kwargs
+        )
 
         self.vpc = aws_ec2.Vpc(
             self,
@@ -26,7 +31,7 @@ class VpcStack(Stack):
                     cidr_mask=24,
                 ),
             ],
-            nat_gateways=nat_gateway_count,
+            nat_gateways=app_config.nat_gateway_count,
         )
 
         self.vpc.add_gateway_endpoint(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aws-cdk-lib>=2.75.0
 aws_cdk.aws_cognito_identitypool_alpha>=2.75.0a0
-eoapi-cdk==5.0.0
+eoapi-cdk==5.2.0
 constructs>=10.0.0,<11.0.0
 pydantic==2.0.2
 pydantic-settings==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aws-cdk-lib>=2.75.0
 aws_cdk.aws_cognito_identitypool_alpha>=2.75.0a0
+aws-cdk.aws-apigatewayv2-alpha==2.95.1a0
 eoapi-cdk==5.4.0
 constructs>=10.0.0,<11.0.0
 pydantic==2.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aws-cdk-lib>=2.75.0
 aws_cdk.aws_cognito_identitypool_alpha>=2.75.0a0
-eoapi-cdk==5.2.0
+eoapi-cdk==5.4.0
 constructs>=10.0.0,<11.0.0
 pydantic==2.0.2
 pydantic-settings==2.0.1


### PR DESCRIPTION
⚠️ large PR

- Add tipg service (closes https://github.com/developmentseed/eoapi-template/issues/11)
- Make bastion host optional via config (closes https://github.com/developmentseed/eoapi-template/issues/6)
- Add deployment docs (closes https://github.com/developmentseed/eoapi-template/issues/8)
- Add CDN and STAC browser options
- Make everything a bit more DRY (the VPC and PGSTACINFRA stack classes take a config as a parameter, rather than listing all the params that I already list _in the config class_ again in the class parameters)
- Bump eoapi-cdk to latest
