### PR TITLE
Use pgbouncer in template deployment

### DIFF
--- a/infrastructure/app.py
+++ b/infrastructure/app.py
@@ -102,7 +102,7 @@ class eoAPIStack(Stack):
             add_pgbouncer=True,
             vpc=vpc,
             engine=aws_rds.DatabaseInstanceEngine.postgres(
-                version=aws_rds.PostgresEngineVersion.VER_14
+                version=aws_rds.PostgresEngineVersion.VER_16
             ),
             vpc_subnets=aws_ec2.SubnetSelection(
                 subnet_type=(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-eoapi-cdk==7.2.0
+eoapi-cdk==7.4.1
 pydantic==2.7
 pydantic-settings[yaml]==2.2.1
 boto3==1.24.15


### PR DESCRIPTION
With eoapi-cdk 7.4.1 we now have the option to add an EC2 instance running `pgbouncer` to the stack which improves performance for greedy Lambda functions!

Also, set the database to use Postgres 16 instead of 14.